### PR TITLE
exportDocument: fix some problems with rsvg-convert

### DIFF
--- a/tools/exportDocument
+++ b/tools/exportDocument
@@ -17,19 +17,9 @@ function scale_width {
 	#Origin is at left bottom
 	OFFSET=`echo "(${WIDTH} - ${NEW_WIDTH}) / 2.0" | bc | sed "s/\..*//g"`
 
-	$PWD/rM2svg -c -i ${BASE}.lines -o ${BASE}.svg
-	for i in `ls ${BASE}_*.svg`
-	do
-		rsvg-convert -w ${NEW_WIDTH} -h ${HEIGHT} -f pdf -o `sed "s/svg/pdf/g" <<< "$i"` `pwd`/$i
-	done
+    create_annotated_pdf ${NEW_WIDTH} ${HEIGHT}
 
-	PDF_FILES=`ls ${BASE}_*.pdf | sort -V`
-	pdftk ${PDF_FILES} cat output ${BASE}_annotations.pdf
-	rm ${PDF_FILES}
-	rm `ls ${BASE}_*.svg`
 	pdfjam --papersize "{${NEW_WIDTH}pt,${HEIGHT}pt}" --offset "${OFFSET}pt 0pt" --outfile ${BASE}_resized.pdf ${BASE}.pdf
-	pdftk ${BASE}_resized.pdf multistamp ${BASE}_annotations.pdf output ${OUTPUT}
-	rm ${BASE}_resized.pdf ${BASE}_annotations.pdf
 }
 
 function scale_height {
@@ -37,19 +27,25 @@ function scale_height {
 	#Origin is at left bottom
 	OFFSET=`echo "(${NEW_HEIGHT} - ${HEIGHT}) / 2.0" | bc | sed "s/\..*//g"`
 
+    create_annotated_pdf ${WIDTH} ${NEW_HEIGHT}
+
+	pdfjam --papersize "{${WIDTH}pt,${NEW_HEIGHT}pt}" --offset "0pt ${OFFSET}pt" --outfile ${BASE}_resized.pdf ${BASE}.pdf
+}
+
+function create_annotated_pdf {
+    WIDTH=$1
+    HEIGHT=$2
+
 	$PWD/rM2svg -i ${BASE}.lines -o ${BASE}.svg
 	for i in `ls ${BASE}_*.svg`
 	do
-		rsvg-convert -w ${WIDTH} -h ${NEW_HEIGHT} -f pdf -o `sed "s/svg/pdf/g" <<< "$i"` `pwd`/$i
+		rsvg-convert -w ${WIDTH} -h ${HEIGHT} -f pdf -o `sed "s/svg/pdf/g" <<< "$i"` `pwd`/$i
 	done
 
 	PDF_FILES=`ls ${BASE}_*.pdf | sort -V`
 	pdftk ${PDF_FILES} cat output ${BASE}_annotations.pdf
 	rm ${PDF_FILES}
 	rm `ls ${BASE}_*.svg`
-	pdfjam --papersize "{${WIDTH}pt,${NEW_HEIGHT}pt}" --offset "0pt ${OFFSET}pt" --outfile ${BASE}_resized.pdf ${BASE}.pdf
-	pdftk ${BASE}_resized.pdf multistamp ${BASE}_annotations.pdf output ${OUTPUT}
-	rm ${BASE}_resized.pdf ${BASE}_annotations.pdf
 }
 
 #0.75 is the ratio of rM tablet width to height
@@ -59,3 +55,6 @@ if [[ ${R} == 1 ]]; then
 else
 	scale_height
 fi
+
+pdftk ${BASE}_resized.pdf multistamp ${BASE}_annotations.pdf output ${OUTPUT}
+rm ${BASE}_resized.pdf ${BASE}_annotations.pdf

--- a/tools/exportDocument
+++ b/tools/exportDocument
@@ -20,7 +20,7 @@ function scale_width {
 	$PWD/rM2svg -c -i ${BASE}.lines -o ${BASE}.svg
 	for i in `ls ${BASE}_*.svg`
 	do
-		rsvg-convert -w ${NEW_WIDTH} -h ${HEIGHT} -f pdf $i > `sed "s/svg/pdf/g" <<< "$i"`
+		rsvg-convert -w ${NEW_WIDTH} -h ${HEIGHT} -f pdf -o `sed "s/svg/pdf/g" <<< "$i"` `pwd`/$i
 	done
 
 	PDF_FILES=`ls ${BASE}_*.pdf | sort -V`
@@ -40,7 +40,7 @@ function scale_height {
 	$PWD/rM2svg -i ${BASE}.lines -o ${BASE}.svg
 	for i in `ls ${BASE}_*.svg`
 	do
-		rsvg-convert -w ${WIDTH} -h ${NEW_HEIGHT} -f pdf $i > `sed "s/svg/pdf/g" <<< "$i"`
+		rsvg-convert -w ${WIDTH} -h ${NEW_HEIGHT} -f pdf -o `sed "s/svg/pdf/g" <<< "$i"` `pwd`/$i
 	done
 
 	PDF_FILES=`ls ${BASE}_*.pdf | sort -V`

--- a/tools/exportDocument
+++ b/tools/exportDocument
@@ -8,8 +8,8 @@ fi
 
 PWD=`dirname "$0"`
 BASE=`basename $1 .lines`
-WIDTH=`pdfinfo ${BASE}.pdf | grep "Page size:" | awk '{print $3}'`
-HEIGHT=`pdfinfo ${BASE}.pdf | grep "Page size:" | awk '{print $5}'`
+WIDTH=`pdfinfo ${BASE}.pdf | grep "Page size:" | awk '{printf "%.0f\n", $3}'`
+HEIGHT=`pdfinfo ${BASE}.pdf | grep "Page size:" | awk '{printf "%.0f\n", $5}'`
 OUTPUT=$2
 
 function scale_width {


### PR DESCRIPTION
This pull request contains three different patches (and fixes) for the exportDocument script. It does not introduce new functionality.

1) adjust for pdfs with non-integer original width and/or height. `rsvg-convert` requires integers for the -w and -h switches, but some pdf may have float dimensions and `exportDocument` didn't consider this.

2) Use absolute path as input for `rsgv-convert`. On my system, rsvg-convert behaves differently when run in a script than when run "by hand". In scripts it seems to interpret input files as `/./<filename>`. Use absolute paths as a workaround.

3) While I was at it, I refactored code to reduce duplicate lines. I hope it's useful for future debugging / modifications :)